### PR TITLE
Implement AttackDb ACL auto-add functionality (COMMON-2)

### DIFF
--- a/src/Jdx.Servers.Http/HttpServer.cs
+++ b/src/Jdx.Servers.Http/HttpServer.cs
@@ -133,10 +133,17 @@ public class HttpServer : ServerBase
                                     return;
                                 }
 
+                                // IPアドレス形式の検証
+                                if (!IPAddress.TryParse(remoteIp, out _))
+                                {
+                                    Logger.LogWarning("Invalid IP address format: {RemoteIp}, skipping ACL add", remoteIp);
+                                    return;
+                                }
+
                                 // 新しいACLエントリを追加
                                 var newAclEntry = new AclEntry
                                 {
-                                    Name = $"AutoBlock_{DateTime.Now:yyyyMMdd_HHmmss}",
+                                    Name = $"AutoBlock_{DateTime.UtcNow:yyyyMMdd_HHmmss_fff}",
                                     Address = remoteIp
                                 };
 


### PR DESCRIPTION
## Summary

Implemented COMMON-2 (High priority): AttackDb ACL自動追加機能

Apache Killer攻撃を検出した際に、攻撃元IPアドレスを自動的にACLリストに追加し、以降のアクセスをブロックする機能を実装しました。

## Changes

### 実装内容
- **AttackDb攻撃検出コールバックの実装**  
  `HttpServer.cs` のTODOコメント部分（106-109行）を完全実装

- **自動ACL追加ロジック**
  - 攻撃検出時に設定ファイルからACL設定を取得
  - 重複チェック（既にACLリストに存在する場合はスキップ）
  - 新しいAClエントリを作成（命名規則: `AutoBlock_yyyyMMdd_HHmmss`）
  - ISettingsService経由で設定を永続化

- **セキュリティチェック**
  - EnableAcl設定がDenyMode(1)であることを確認
  - Allow modeの場合は警告ログを出力して処理をスキップ

- **スレッドセーフ実装**
  - 既存の`_settingsLock`（ReaderWriterLockSlim）を使用
  - Task.Runによるバックグラウンド実行でリクエスト処理をブロックしない

- **エラーハンドリング**
  - try-catchによる包括的なエラー処理
  - 詳細なログ出力（Warning、Information、Error各レベル）

### 技術的詳細
- **非同期処理**: `Task.Run`でACL追加処理をバックグラウンド実行
- **重複防止**: `Linq.Any()`で既存エントリをチェック
- **命名規則**: `AutoBlock_{DateTime.Now:yyyyMMdd_HHmmss}`形式
- **設定永続化**: `ISettingsService.SaveSettingsAsync()`で保存

## Test Plan

以下のシナリオで動作確認を推奨します：

- [ ] **基本動作確認**
  - UseAutoAcl = true, EnableAcl = 1 (Deny mode) で起動
  - Apache Killer攻撃をシミュレート（大量のRange requestsを送信）
  - ACLリストに攻撃元IPが自動追加されることを確認
  - 設定ファイルに永続化されることを確認

- [ ] **ACL mode検証**
  - EnableAcl = 0 (Allow mode) で攻撃を検出
  - 警告ログが出力され、ACLに追加されないことを確認

- [ ] **重複チェック検証**
  - 同一IPから複数回攻撃を検出
  - 2回目以降は「already in ACL list」ログが出力されることを確認
  - ACLリストに重複エントリが作成されないことを確認

- [ ] **ブロック動作確認**
  - ACL追加後、同一IPからのアクセスが403 Forbiddenで拒否されることを確認

- [ ] **スレッドセーフ性確認**
  - 複数の攻撃を同時検出した場合でも正常に動作することを確認

## Security Benefits

- ✅ **自動防御**: 攻撃検出から防御まで完全自動化
- ✅ **永続的ブロック**: 設定ファイルに保存されるため再起動後も有効
- ✅ **運用負荷軽減**: 手動でのACL設定が不要
- ✅ **攻撃履歴の記録**: エントリ名に日時が含まれるため攻撃履歴を追跡可能

## Completes

- [x] **COMMON-2**: AttackDb ACL自動追加機能（High優先度）

残りのHigh優先度項目:
- [ ] **COMMON-1**: SSL/TLS完全統合（大規模変更のため別PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)