### PR TITLE
Fix: Hide HTTP settings menu when no Virtual Hosts configured

### DIFF
--- a/src/Jdx.WebUI/Components/Layout/NavMenu.razor
+++ b/src/Jdx.WebUI/Components/Layout/NavMenu.razor
@@ -49,22 +49,7 @@
                                 <!-- Virtual Hosts management always first -->
                                 <NavLink class="nav-link submenu-item" href="settings/http/virtualhost">Virtual Hosts</NavLink>
 
-                                @if (virtualHosts == null || virtualHosts.Count == 0)
-                                {
-                                    <!-- Default HTTP settings (when no Virtual Hosts) -->
-                                    <NavLink class="nav-link submenu-item" href="settings/http/general">General</NavLink>
-                                    <NavLink class="nav-link submenu-item" href="settings/http/document">Document</NavLink>
-                                    <NavLink class="nav-link submenu-item" href="settings/http/cgi">CGI</NavLink>
-                                    <NavLink class="nav-link submenu-item" href="settings/http/ssi">SSI</NavLink>
-                                    <NavLink class="nav-link submenu-item" href="settings/http/webdav">WebDAV</NavLink>
-                                    <NavLink class="nav-link submenu-item" href="settings/http/alias-mime">Alias & MIME</NavLink>
-                                    <NavLink class="nav-link submenu-item" href="settings/http/authentication">Authentication</NavLink>
-                                    <NavLink class="nav-link submenu-item" href="settings/http/template">Template</NavLink>
-                                    <NavLink class="nav-link submenu-item" href="settings/http/acl">ACL</NavLink>
-                                    <NavLink class="nav-link submenu-item" href="settings/http/ssl">SSL/TLS</NavLink>
-                                    <NavLink class="nav-link submenu-item" href="settings/http/advanced">Advanced</NavLink>
-                                }
-                                else
+                                @if (virtualHosts != null && virtualHosts.Count > 0)
                                 {
                                     <!-- Virtual Hosts with individual settings -->
                                     @foreach (var (vhost, index) in virtualHosts.Select((v, i) => (v, i)))


### PR DESCRIPTION
## Summary

This PR fixes the navigation menu display logic to hide HTTP settings menu items when no Virtual Hosts are configured.

## Issue

Previously, when `VirtualHosts` list was empty in `appsettings.json`, the HTTP/HTTPS menu still displayed all default settings items (General, Document, CGI, SSI, WebDAV, Alias & MIME, Authentication, Template, ACL, SSL/TLS, Advanced). These menu items were not functional since they require Virtual Host routing parameters.

## Changes

### Navigation Menu Logic Update
- Modified `NavMenu.razor` to conditionally display HTTP settings based on Virtual Host configuration
- When `VirtualHosts` list is empty or null:
  - Only "Virtual Hosts" management link is displayed
  - All other HTTP settings menu items are hidden
- When Virtual Hosts are configured:
  - Virtual Host-specific settings are displayed under each Virtual Host
  - Users can expand individual Virtual Hosts to access their settings

## Before
```
HTTP/HTTPS ▼
  └─ Virtual Hosts
  └─ General          ← Shown but not functional
  └─ Document         ← Shown but not functional
  └─ CGI              ← Shown but not functional
  └─ ... (etc)        ← Shown but not functional
```

## After
```
HTTP/HTTPS ▼
  └─ Virtual Hosts    ← Only this is shown
```

## Test Plan

- [x] Verify menu with `VirtualHosts: []` shows only "Virtual Hosts" link
- [x] Verify menu with configured Virtual Hosts shows all Virtual Host entries
- [x] Confirm Virtual Host management page is accessible
- [x] Test expanding Virtual Hosts shows per-host settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)