### PR TITLE
WebUI: メニュー順序統一（ACLをGeneralの直後に配置）

### DIFF
--- a/src/Jdx.WebUI/Components/Layout/NavMenu.razor
+++ b/src/Jdx.WebUI/Components/Layout/NavMenu.razor
@@ -68,6 +68,7 @@
                                             {
                                                 <div class="submenu-subitems">
                                                     <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/general")">General</NavLink>
+                                                    <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/acl")">ACL</NavLink>
                                                     <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/document")">Document</NavLink>
                                                     <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/cgi")">CGI</NavLink>
                                                     <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/ssi")">SSI</NavLink>
@@ -75,7 +76,6 @@
                                                     <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/alias-mime")">Alias & MIME</NavLink>
                                                     <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/authentication")">Authentication</NavLink>
                                                     <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/template")">Template</NavLink>
-                                                    <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/acl")">ACL</NavLink>
                                                     <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/ssl")">SSL/TLS</NavLink>
                                                     <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/advanced")">Advanced</NavLink>
                                                 </div>
@@ -97,9 +97,9 @@
                         {
                             <div class="submenu-items">
                                 <NavLink class="nav-link submenu-item" href="settings/ftp/general">General</NavLink>
+                                <NavLink class="nav-link submenu-item" href="settings/ftp/acl">ACL</NavLink>
                                 <NavLink class="nav-link submenu-item" href="settings/ftp/virtualfolder">Virtual Folder</NavLink>
                                 <NavLink class="nav-link submenu-item" href="settings/ftp/user">User</NavLink>
-                                <NavLink class="nav-link submenu-item" href="settings/ftp/acl">ACL</NavLink>
                             </div>
                         }
                     </div>
@@ -114,9 +114,9 @@
                         {
                             <div class="submenu-items">
                                 <NavLink class="nav-link submenu-item" href="settings/dns/general">General</NavLink>
+                                <NavLink class="nav-link submenu-item" href="settings/dns/acl">ACL</NavLink>
                                 <NavLink class="nav-link submenu-item" href="settings/dns/domains">Domains</NavLink>
                                 <NavLink class="nav-link submenu-item" href="settings/dns/resources">Resources</NavLink>
-                                <NavLink class="nav-link submenu-item" href="settings/dns/acl">ACL</NavLink>
                             </div>
                         }
                     </div>
@@ -161,9 +161,9 @@
                         {
                             <div class="submenu-items">
                                 <NavLink class="nav-link submenu-item" href="settings/pop3/general">General</NavLink>
+                                <NavLink class="nav-link submenu-item" href="settings/pop3/acl">ACL</NavLink>
                                 <NavLink class="nav-link submenu-item" href="settings/pop3/changepassword">Change Password</NavLink>
                                 <NavLink class="nav-link submenu-item" href="settings/pop3/autodeny">Auto Deny</NavLink>
-                                <NavLink class="nav-link submenu-item" href="settings/pop3/acl">ACL</NavLink>
                             </div>
                         }
                     </div>
@@ -178,6 +178,7 @@
                         {
                             <div class="submenu-items">
                                 <NavLink class="nav-link submenu-item" href="settings/smtp/general">General</NavLink>
+                                <NavLink class="nav-link submenu-item" href="settings/smtp/acl">ACL</NavLink>
                                 <NavLink class="nav-link submenu-item" href="settings/smtp/esmtp">ESMTP</NavLink>
                                 <NavLink class="nav-link submenu-item" href="settings/smtp/relay">Relay</NavLink>
                                 <NavLink class="nav-link submenu-item" href="settings/smtp/queue">Queue</NavLink>
@@ -185,7 +186,6 @@
                                 <NavLink class="nav-link submenu-item" href="settings/smtp/header">Header</NavLink>
                                 <NavLink class="nav-link submenu-item" href="settings/smtp/aliases">Aliases</NavLink>
                                 <NavLink class="nav-link submenu-item" href="settings/smtp/autoreception">Auto Reception</NavLink>
-                                <NavLink class="nav-link submenu-item" href="settings/smtp/acl">ACL</NavLink>
                             </div>
                         }
                     </div>


### PR DESCRIPTION
## Summary
- 全サービスのナビゲーションメニューでACLをGeneralの直後に移動
- セキュリティ設定へのアクセス性を向上

## Changes
- HTTP/HTTPS Virtual Host: General → ACL → Document → ...
- FTP: General → ACL → Virtual Folder → User
- DNS: General → ACL → Domains → Resources
- POP3: General → ACL → Change Password → Auto Deny
- SMTP: General → ACL → ESMTP → Relay → ...

## Test plan
- [ ] HTTP/HTTPS Virtual Hostのメニュー順序を確認
- [ ] FTPのメニュー順序を確認
- [ ] DNSのメニュー順序を確認
- [ ] POP3のメニュー順序を確認
- [ ] SMTPのメニュー順序を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)