### PR TITLE
Logs: TIME表示形式の選択機能を追加

### DIFF
--- a/src/Jdx.WebUI/Components/Pages/Logs.razor
+++ b/src/Jdx.WebUI/Components/Pages/Logs.razor
@@ -29,6 +29,15 @@
                 Error
             </button>
         </div>
+        <div class="logs-options-group">
+            <label class="time-format-label">Time:</label>
+            <select class="time-format-select" @bind="selectedTimeFormat">
+                @foreach (var format in timeFormats)
+                {
+                    <option value="@format.Key">@format.Key</option>
+                }
+            </select>
+        </div>
         <div class="btn-group">
             <button class="btn btn-dashboard btn-dashboard-secondary" @onclick="ClearLogs">
                 Clear Logs
@@ -82,7 +91,7 @@
                         {
                             <tr>
                                 <td class="text-nowrap">
-                                    <small>@log.Timestamp.ToString("HH:mm:ss.fff")</small>
+                                    <small>@log.Timestamp.ToString(GetTimeFormat())</small>
                                 </td>
                                 <td>
                                     <span class="log-level-badge @GetLevelBadgeClass(log.Level)">
@@ -160,6 +169,38 @@
     .resize-handle:active {
         background-color: rgba(66, 153, 225, 0.5);
     }
+
+    .logs-options-group {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-left: auto;
+        margin-right: 1rem;
+    }
+
+    .time-format-label {
+        color: var(--text-secondary);
+        font-size: 0.875rem;
+        font-weight: 500;
+        margin: 0;
+    }
+
+    .time-format-select {
+        padding: 0.375rem 0.75rem;
+        font-size: 0.875rem;
+        border: 1px solid var(--card-border);
+        border-radius: 6px;
+        background-color: white;
+        color: var(--text-primary);
+        cursor: pointer;
+        min-width: 180px;
+    }
+
+    .time-format-select:focus {
+        outline: none;
+        border-color: var(--btn-primary);
+        box-shadow: 0 0 0 2px rgba(45, 55, 72, 0.1);
+    }
 </style>
 
 <script>
@@ -228,6 +269,15 @@
     private int timeWidth = 150;
     private int levelWidth = 100;
     private int categoryWidth = 250;
+
+    // Time format options
+    private static readonly Dictionary<string, string> timeFormats = new()
+    {
+        { "yyyy/MM/dd HH:mm:ss.fff", "yyyy/MM/dd HH:mm:ss.fff" },
+        { "yyyy/MM/dd HH:mm:ss", "yyyy/MM/dd HH:mm:ss" },
+        { "HH:mm:ss.fff", "HH:mm:ss.fff" }
+    };
+    private string selectedTimeFormat = "HH:mm:ss.fff";
 
     protected override void OnInitialized()
     {
@@ -301,6 +351,11 @@
             LogLevel.Trace => "debug",
             _ => "secondary"
         };
+    }
+
+    private string GetTimeFormat()
+    {
+        return timeFormats.TryGetValue(selectedTimeFormat, out var format) ? format : "HH:mm:ss.fff";
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- LogsページでTIMEカラムの表示形式を選択できる機能を追加
- ドロップダウンで3つの形式から選択可能

## 選択可能な形式
- `yyyy/MM/dd HH:mm:ss.fff` - フル形式（日付+時刻+ミリ秒）
- `yyyy/MM/dd HH:mm:ss` - ミリ秒なし
- `HH:mm:ss.fff` - 時刻のみ（デフォルト）

## 変更内容
- TIME形式選択ドロップダウンをコントロールバーに追加
- 選択した形式でログのタイムスタンプを表示

Closes #40

## Test plan
- [ ] Logsページを開き、TIME形式選択ドロップダウンが表示されることを確認
- [ ] 各形式を選択し、ログのTIME列が選択した形式で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)