### PR TITLE
Logs: CATEGORYフィルタ機能を追加

### DIFF
--- a/src/Jdx.WebUI/Components/Pages/Logs.razor
+++ b/src/Jdx.WebUI/Components/Pages/Logs.razor
@@ -30,8 +30,18 @@
             </button>
         </div>
         <div class="logs-options-group">
-            <label class="time-format-label">Time:</label>
-            <select class="time-format-select" @bind="selectedTimeFormat">
+            <label class="filter-label">Category:</label>
+            <select class="filter-select" @bind="selectedCategory" @bind:after="ApplyFilter">
+                <option value="">All</option>
+                @foreach (var category in availableCategories)
+                {
+                    <option value="@category">@category</option>
+                }
+            </select>
+        </div>
+        <div class="logs-options-group">
+            <label class="filter-label">Time:</label>
+            <select class="filter-select" @bind="selectedTimeFormat">
                 @foreach (var format in timeFormats)
                 {
                     <option value="@format.Key">@format.Key</option>
@@ -178,14 +188,14 @@
         margin-right: 1rem;
     }
 
-    .time-format-label {
+    .filter-label {
         color: var(--text-secondary);
         font-size: 0.875rem;
         font-weight: 500;
         margin: 0;
     }
 
-    .time-format-select {
+    .filter-select {
         padding: 0.375rem 0.75rem;
         font-size: 0.875rem;
         border: 1px solid var(--card-border);
@@ -193,10 +203,10 @@
         background-color: white;
         color: var(--text-primary);
         cursor: pointer;
-        min-width: 180px;
+        min-width: 150px;
     }
 
-    .time-format-select:focus {
+    .filter-select:focus {
         outline: none;
         border-color: var(--btn-primary);
         box-shadow: 0 0 0 2px rgba(45, 55, 72, 0.1);
@@ -279,6 +289,10 @@
     };
     private string selectedTimeFormat = "HH:mm:ss.fff";
 
+    // Category filter
+    private string selectedCategory = "";
+    private List<string> availableCategories = new();
+
     protected override void OnInitialized()
     {
         LoadLogs();
@@ -298,7 +312,18 @@
     private void LoadLogs()
     {
         logs = LogService.GetRecentLogs(100).ToList();
+        UpdateAvailableCategories();
         ApplyFilter();
+    }
+
+    private void UpdateAvailableCategories()
+    {
+        availableCategories = logs
+            .Select(l => l.Category)
+            .Where(c => !string.IsNullOrEmpty(c))
+            .Distinct()
+            .OrderBy(c => c)
+            .ToList();
     }
 
     private void FilterByLevel(LogLevel? level)
@@ -309,14 +334,21 @@
 
     private void ApplyFilter()
     {
+        IEnumerable<LogEntry> result = logs;
+
+        // Filter by level
         if (selectedLevel.HasValue)
         {
-            filteredLogs = logs.Where(l => l.Level == selectedLevel.Value);
+            result = result.Where(l => l.Level == selectedLevel.Value);
         }
-        else
+
+        // Filter by category
+        if (!string.IsNullOrEmpty(selectedCategory))
         {
-            filteredLogs = logs;
+            result = result.Where(l => l.Category == selectedCategory);
         }
+
+        filteredLogs = result;
     }
 
     private void ClearLogs()


### PR DESCRIPTION
## Summary
- LogsページでCATEGORY（カテゴリ）別にログをフィルタする機能を追加
- 既存のログレベルフィルタと併用可能

## 機能
- カテゴリ一覧ドロップダウンから選択してフィルタリング
- ログから動的にカテゴリ一覧を生成（ServerManager, HttpServer, FtpServer など）
- 「All」を選択すると全カテゴリを表示

Closes #41

## Test plan
- [ ] Logsページを開き、Categoryドロップダウンが表示されることを確認
- [ ] カテゴリを選択し、該当カテゴリのログのみ表示されることを確認
- [ ] ログレベルフィルタとカテゴリフィルタを併用できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)