### PR TITLE
HTTPS有効化時の証明書検証機能を実装

### DIFF
--- a/src/Jdx.Core/Settings/ApplicationSettings.cs
+++ b/src/Jdx.Core/Settings/ApplicationSettings.cs
@@ -199,6 +199,9 @@ public class VirtualHostEntry
 /// </summary>
 public class VirtualHostSettings
 {
+    // プロトコル設定
+    public string Protocol { get; set; } = "HTTP";  // HTTP or HTTPS
+
     // ドキュメント設定 (Document)
     public string DocumentRoot { get; set; } = "";
     public string WelcomeFileName { get; set; } = "index.html";

--- a/src/Jdx.Servers.Http/HttpServer.cs
+++ b/src/Jdx.Servers.Http/HttpServer.cs
@@ -124,7 +124,7 @@ public class HttpServer : ServerBase
         }
 
         // SSL/TLS初期化
-        _sslManager = new HttpSslManager(settings.CertificateFile, settings.CertificatePassword, Logger);
+        _sslManager = new HttpSslManager(settings.Protocol, settings.CertificateFile, settings.CertificatePassword, Logger);
         if (_sslManager.IsEnabled)
         {
             Logger.LogInformation("HTTPS/SSL enabled with certificate: {Subject}", _sslManager.Certificate?.Subject ?? "unknown");
@@ -231,7 +231,7 @@ public class HttpServer : ServerBase
         {
             // サーバー基本設定（VirtualHostで個別化）
             Enabled = virtualHostEntry.Enabled,
-            Protocol = parentSettings.Protocol,  // 親設定を使用
+            Protocol = vhostSettings.Protocol,  // VirtualHostの設定を使用
             Port = virtualHostEntry.GetPort(),    // VirtualHostのポート
             BindAddress = virtualHostEntry.BindAddress ?? parentSettings.BindAddress,  // VirtualHostで指定がなければ親を使用
             UseResolve = parentSettings.UseResolve,

--- a/src/Jdx.Servers.Http/HttpSslManager.cs
+++ b/src/Jdx.Servers.Http/HttpSslManager.cs
@@ -19,14 +19,21 @@ public class HttpSslManager
     public bool IsEnabled => _isEnabled;
     public X509Certificate2? Certificate => _certificate;
 
-    public HttpSslManager(string? certificateFile, string? certificatePassword, ILogger logger)
+    public HttpSslManager(string? protocol, string? certificateFile, string? certificatePassword, ILogger logger)
     {
         _logger = logger;
         _isEnabled = false;
 
+        // Protocolが"HTTPS"でない場合、SSL/TLSを無効化
+        if (protocol != "HTTPS")
+        {
+            _logger.LogInformation("SSL/TLS disabled (Protocol is set to {Protocol})", protocol ?? "HTTP");
+            return;
+        }
+
         if (string.IsNullOrEmpty(certificateFile))
         {
-            _logger.LogInformation("SSL/TLS not configured (no certificate file specified)");
+            _logger.LogWarning("SSL/TLS cannot be enabled: Protocol is HTTPS but no certificate file specified");
             return;
         }
 

--- a/src/Jdx.WebUI/Components/Pages/Settings/Http/General.razor
+++ b/src/Jdx.WebUI/Components/Pages/Settings/Http/General.razor
@@ -2,7 +2,10 @@
 @rendermode InteractiveServer
 @using Jdx.Core.Settings
 @using Jdx.WebUI.Services
+@using System.Net.Http.Json
 @inject ISettingsService SettingsService
+@inject HttpClient HttpClient
+@inject IJSRuntime JSRuntime
 
 <PageTitle>HTTP General Settings - JumboDogX</PageTitle>
 
@@ -78,7 +81,7 @@
                 <div class="col-md-6">
                     <div class="form-check form-switch">
                         <input class="form-check-input" type="checkbox" id="enableHttps"
-                               checked="@enableHttps" @onchange="OnEnableHttpsChanged">
+                               checked="@enableHttps" @onclick="OnEnableHttpsClicked" @onclick:preventDefault="true">
                         <label class="form-check-label" for="enableHttps">
                             Enable HTTPS
                         </label>
@@ -128,10 +131,66 @@
         enableHttps = settings.HttpServer.Protocol == "HTTPS";
     }
 
-    private void OnEnableHttpsChanged(ChangeEventArgs e)
+    private async Task OnEnableHttpsClicked()
     {
-        enableHttps = (bool)(e.Value ?? false);
-        settings.HttpServer.Protocol = enableHttps ? "HTTPS" : "HTTP";
+        // 現在の状態を確認
+        // クリックにより、OFFからONにしようとしている場合
+        if (!enableHttps)
+        {
+            // HTTPSを有効にしようとしている場合、証明書を検証
+            try
+            {
+                var validationRequest = new
+                {
+                    certificateFile = settings.HttpServer.CertificateFile,
+                    certificatePassword = settings.HttpServer.CertificatePassword
+                };
+
+                var response = await HttpClient.PostAsJsonAsync("/api/CertificateValidation/validate", validationRequest);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var result = await response.Content.ReadFromJsonAsync<CertificateValidationResponse>();
+
+                    if (result != null && result.IsValid)
+                    {
+                        // 検証成功 - HTTPSを有効化
+                        enableHttps = true;
+                        settings.HttpServer.Protocol = "HTTPS";
+                    }
+                    else
+                    {
+                        // 検証失敗 - エラーをポップアップ表示
+                        await JSRuntime.InvokeVoidAsync("alert", result?.ErrorMessage ?? "証明書の検証に失敗しました。");
+
+                        // スイッチはOFFのまま（enableHttpsを変更しない）
+                    }
+                }
+                else
+                {
+                    await JSRuntime.InvokeVoidAsync("alert", "証明書の検証APIの呼び出しに失敗しました。");
+                }
+            }
+            catch (Exception ex)
+            {
+                await JSRuntime.InvokeVoidAsync("alert", $"証明書の検証中にエラーが発生しました: {ex.Message}");
+            }
+        }
+        else
+        {
+            // ONからOFFにする場合は検証不要
+            enableHttps = false;
+            settings.HttpServer.Protocol = "HTTP";
+        }
+
+        StateHasChanged();
+    }
+
+    // 証明書検証レスポンス用のクラス
+    private class CertificateValidationResponse
+    {
+        public bool IsValid { get; set; }
+        public string? ErrorMessage { get; set; }
     }
 
     private async Task SaveSettings()

--- a/src/Jdx.WebUI/Components/Pages/Settings/Http/VirtualHostGeneral.razor
+++ b/src/Jdx.WebUI/Components/Pages/Settings/Http/VirtualHostGeneral.razor
@@ -2,7 +2,10 @@
 @rendermode InteractiveServer
 @using Jdx.Core.Settings
 @using Jdx.WebUI.Services
+@using System.Net.Http.Json
 @inject ISettingsService SettingsService
+@inject HttpClient HttpClient
+@inject IJSRuntime JSRuntime
 
 <PageTitle>HTTP Virtual Host Settings - JumboDogX</PageTitle>
 
@@ -77,7 +80,7 @@
                 <div class="col-md-6">
                     <div class="form-check form-switch">
                         <input class="form-check-input" type="checkbox" id="enableHttps"
-                               checked="@enableHttps" @onchange="OnEnableHttpsChanged">
+                               checked="@enableHttps" @onclick="OnEnableHttpsClicked" @onclick:preventDefault="true">
                         <label class="form-check-label" for="enableHttps">
                             Enable HTTPS
                         </label>
@@ -143,15 +146,72 @@
                 // Extract port from Host (e.g., "example.com:8080" -> 8080)
                 port = currentVHostEntry.GetPort();
 
-                // Determine HTTPS from certificate presence
-                enableHttps = !string.IsNullOrEmpty(currentVHostSettings.CertificateFile);
+                // Determine HTTPS from Protocol property
+                enableHttps = currentVHostSettings.Protocol == "HTTPS";
             }
         }
     }
 
-    private void OnEnableHttpsChanged(ChangeEventArgs e)
+    private async Task OnEnableHttpsClicked()
     {
-        enableHttps = (bool)(e.Value ?? false);
+        // 現在の状態を確認
+        // クリックにより、OFFからONにしようとしている場合
+        if (!enableHttps)
+        {
+            // HTTPSを有効にしようとしている場合、証明書を検証
+            try
+            {
+                var validationRequest = new
+                {
+                    certificateFile = currentVHostSettings.CertificateFile,
+                    certificatePassword = currentVHostSettings.CertificatePassword
+                };
+
+                var response = await HttpClient.PostAsJsonAsync("/api/CertificateValidation/validate", validationRequest);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var result = await response.Content.ReadFromJsonAsync<CertificateValidationResponse>();
+
+                    if (result != null && result.IsValid)
+                    {
+                        // 検証成功 - HTTPSを有効化
+                        enableHttps = true;
+                        currentVHostSettings.Protocol = "HTTPS";
+                    }
+                    else
+                    {
+                        // 検証失敗 - エラーをポップアップ表示
+                        await JSRuntime.InvokeVoidAsync("alert", result?.ErrorMessage ?? "証明書の検証に失敗しました。");
+
+                        // スイッチはOFFのまま（enableHttpsを変更しない）
+                    }
+                }
+                else
+                {
+                    await JSRuntime.InvokeVoidAsync("alert", "証明書の検証APIの呼び出しに失敗しました。");
+                }
+            }
+            catch (Exception ex)
+            {
+                await JSRuntime.InvokeVoidAsync("alert", $"証明書の検証中にエラーが発生しました: {ex.Message}");
+            }
+        }
+        else
+        {
+            // ONからOFFにする場合は検証不要
+            enableHttps = false;
+            currentVHostSettings.Protocol = "HTTP";
+        }
+
+        StateHasChanged();
+    }
+
+    // 証明書検証レスポンス用のクラス
+    private class CertificateValidationResponse
+    {
+        public bool IsValid { get; set; }
+        public string? ErrorMessage { get; set; }
     }
 
     private async Task SaveSettings()

--- a/src/Jdx.WebUI/Controllers/CertificateValidationController.cs
+++ b/src/Jdx.WebUI/Controllers/CertificateValidationController.cs
@@ -1,0 +1,135 @@
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jdx.WebUI.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class CertificateValidationController : ControllerBase
+{
+    private readonly ILogger<CertificateValidationController> _logger;
+
+    public CertificateValidationController(ILogger<CertificateValidationController> logger)
+    {
+        _logger = logger;
+    }
+
+    [HttpPost("validate")]
+    public IActionResult ValidateCertificate([FromBody] CertificateValidationRequest request)
+    {
+        try
+        {
+            // 1. 証明書ファイルが設定されているかチェック
+            if (string.IsNullOrWhiteSpace(request.CertificateFile))
+            {
+                return Ok(new CertificateValidationResponse
+                {
+                    IsValid = false,
+                    ErrorMessage = "証明書ファイルが設定されていません。"
+                });
+            }
+
+            // 2. ファイルが存在するかチェック
+            if (!System.IO.File.Exists(request.CertificateFile))
+            {
+                return Ok(new CertificateValidationResponse
+                {
+                    IsValid = false,
+                    ErrorMessage = $"証明書ファイルが見つかりません: {request.CertificateFile}"
+                });
+            }
+
+            // 3. 証明書の読み込みとパスワード検証
+            X509Certificate2? certificate = null;
+            try
+            {
+                certificate = X509CertificateLoader.LoadPkcs12FromFile(
+                    request.CertificateFile,
+                    request.CertificatePassword);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to load certificate from {File}", request.CertificateFile);
+
+                // パスワードエラーか、証明書形式エラーかを判定
+                if (ex.Message.Contains("password") || ex.Message.Contains("invalid password"))
+                {
+                    return Ok(new CertificateValidationResponse
+                    {
+                        IsValid = false,
+                        ErrorMessage = "証明書のパスワードが正しくありません。"
+                    });
+                }
+
+                return Ok(new CertificateValidationResponse
+                {
+                    IsValid = false,
+                    ErrorMessage = $"証明書の読み込みに失敗しました: {ex.Message}"
+                });
+            }
+
+            // 4. 証明書の有効期限チェック
+            if (certificate.NotAfter < DateTime.Now)
+            {
+                return Ok(new CertificateValidationResponse
+                {
+                    IsValid = false,
+                    ErrorMessage = $"証明書の有効期限が切れています (有効期限: {certificate.NotAfter:yyyy/MM/dd})"
+                });
+            }
+
+            if (certificate.NotBefore > DateTime.Now)
+            {
+                return Ok(new CertificateValidationResponse
+                {
+                    IsValid = false,
+                    ErrorMessage = $"証明書はまだ有効ではありません (有効開始日: {certificate.NotBefore:yyyy/MM/dd})"
+                });
+            }
+
+            // すべての検証に成功
+            return Ok(new CertificateValidationResponse
+            {
+                IsValid = true,
+                ErrorMessage = null,
+                CertificateInfo = new CertificateInfo
+                {
+                    Subject = certificate.Subject,
+                    Issuer = certificate.Issuer,
+                    NotBefore = certificate.NotBefore,
+                    NotAfter = certificate.NotAfter
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error during certificate validation");
+            return Ok(new CertificateValidationResponse
+            {
+                IsValid = false,
+                ErrorMessage = $"証明書の検証中に予期しないエラーが発生しました: {ex.Message}"
+            });
+        }
+    }
+}
+
+public class CertificateValidationRequest
+{
+    public string CertificateFile { get; set; } = "";
+    public string? CertificatePassword { get; set; }
+}
+
+public class CertificateValidationResponse
+{
+    public bool IsValid { get; set; }
+    public string? ErrorMessage { get; set; }
+    public CertificateInfo? CertificateInfo { get; set; }
+}
+
+public class CertificateInfo
+{
+    public string Subject { get; set; } = "";
+    public string Issuer { get; set; } = "";
+    public DateTime NotBefore { get; set; }
+    public DateTime NotAfter { get; set; }
+}

--- a/src/Jdx.WebUI/Program.cs
+++ b/src/Jdx.WebUI/Program.cs
@@ -31,6 +31,17 @@ builder.Host.UseSerilog();
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
+// Add API Controllers support
+builder.Services.AddControllers();
+
+// Add HttpClient for internal API calls
+builder.Services.AddScoped(sp =>
+{
+    var client = new HttpClient();
+    client.BaseAddress = new Uri("http://localhost:5001");
+    return client;
+});
+
 // Add JumboDogX services
 builder.Services.AddSingleton<LogService>();
 builder.Services.AddSingleton<ISettingsService, SettingsService>();
@@ -57,6 +68,7 @@ app.UseStaticFiles();
 app.UseRouting();
 app.UseAntiforgery();
 
+app.MapControllers();
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 


### PR DESCRIPTION
## 概要

HTTPS有効化時にSSL/TLS証明書の検証を行い、証明書が正しく設定されていない場合はHTTPSを有効化できないようにする機能を実装しました。

## 変更内容

### 1. Protocol属性の追加とHTTP/HTTPS制御の改善

- `VirtualHostSettings`クラスに`Protocol`属性を追加（デフォルト: "HTTP"）
- `HttpSslManager`のコンストラクタに`protocol`パラメータを追加
- Protocol属性が"HTTPS"の場合のみSSL/TLSを有効化
- `HttpServer`クラスで各VirtualHostのProtocol設定を反映

これにより、VirtualHost単位でHTTP/HTTPSの制御が可能になり、証明書が設定されていてもProtocolが"HTTP"の場合はSSLを無効化できます。

**変更ファイル:**
- `src/Jdx.Core/Settings/ApplicationSettings.cs`
- `src/Jdx.Servers.Http/HttpSslManager.cs`
- `src/Jdx.Servers.Http/HttpServer.cs`

### 2. SSL/TLS証明書検証APIの実装

包括的な証明書検証を行うWeb APIを実装しました。

**検証内容:**
- 証明書ファイルの存在確認
- 証明書パスワードの検証
- 証明書の有効期限チェック（NotBefore/NotAfter）

検証失敗時には日本語のエラーメッセージを返し、成功時には証明書情報（Subject、Issuer、有効期限）を返します。

**変更ファイル:**
- `src/Jdx.WebUI/Controllers/CertificateValidationController.cs`（新規作成）
- `src/Jdx.WebUI/Program.cs`（APIコントローラーサポート追加）

### 3. UI側の証明書検証とスイッチ制御の改善

**主な変更:**
- `@onclick`イベントに`@onclick:preventDefault`を追加しデフォルト動作を抑制
- 証明書未設定時やパスワード誤り時にポップアップでエラーを表示
- 検証失敗時はスイッチをOFFのまま維持
- 検証成功時のみHTTPSを有効化し`Protocol`属性を"HTTPS"に設定
- `OnInitialized`で`Protocol`属性から`enableHttps`状態を復元

**変更ファイル:**
- `src/Jdx.WebUI/Components/Pages/Settings/Http/General.razor`
- `src/Jdx.WebUI/Components/Pages/Settings/Http/VirtualHostGeneral.razor`

## 動作仕様

証明書が設定されていない状態で「Enable HTTPS」スイッチをクリックすると:
1. 証明書検証APIが呼ばれます
2. 検証が失敗した場合、エラーメッセージがポップアップ表示されます
3. スイッチは視覚的にOFFの状態を維持します

検証が成功した場合のみ、スイッチがONになりHTTPSが有効化されます。

## テスト

以下の動作を確認してください:

- [ ] 証明書未設定時、HTTPSスイッチをONにしようとするとエラーが表示され、スイッチがOFFのままになる
- [ ] 証明書パスワードが誤っている場合、エラーが表示されスイッチがOFFのままになる
- [ ] 証明書の有効期限が切れている場合、エラーが表示されスイッチがOFFのままになる
- [ ] 正しい証明書が設定されている場合、HTTPSスイッチをONにできる
- [ ] VirtualHost設定画面でも同様の動作をする

## 統計

- 7ファイル変更
- 289行追加、13行削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)