### PR TITLE
VirtualHost配下のメニューからSSL/TLS項目を削除

### DIFF
--- a/src/Jdx.WebUI/Components/Layout/NavMenu.razor
+++ b/src/Jdx.WebUI/Components/Layout/NavMenu.razor
@@ -76,7 +76,6 @@
                                                     <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/alias-mime")">Alias & MIME</NavLink>
                                                     <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/authentication")">Authentication</NavLink>
                                                     <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/template")">Template</NavLink>
-                                                    <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/ssl")">SSL/TLS</NavLink>
                                                     <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/advanced")">Advanced</NavLink>
                                                 </div>
                                             }


### PR DESCRIPTION
## 概要
Issue #56 の対応として、VirtualHost配下のメニューからSSL/TLS項目を削除しました。

## 背景
VirtualHost（例: example.com）配下のメニューにSSL/TLS項目が表示されていますが、SSL/TLSの設定は実際には「General」ページ内に存在します。メニューツリーに重複して表示する必要がないため、削除しました。

## 変更内容

### NavMenu.razorの修正
- `src/Jdx.WebUI/Components/Layout/NavMenu.razor`の79行目からSSL/TLS項目を削除
- VirtualHost配下のメニュー構造を以下のように変更:
  - General
  - ACL
  - Document
  - CGI
  - SSI
  - WebDAV
  - Alias & MIME
  - Authentication
  - Template
  - ~~SSL/TLS~~ ← **削除**
  - Advanced

## 影響範囲

- ✅ Generalページ内のSSL/TLS設定機能はそのまま維持
- ✅ メニューUIのみの変更のため、機能への影響なし
- ✅ ビルド成功（7個の警告、0エラー）

## テスト

- ✅ ビルド成功
- ✅ メニュー構造からSSL/TLS項目が削除されたことを確認

## 関連Issue

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)