### PR TITLE
Fix: ACLでDenyされた時にWeb UIのログビューアにログが表示されない問題を修正 (#60)

### DIFF
--- a/src/Jdx.Servers.Http/HttpServer.cs
+++ b/src/Jdx.Servers.Http/HttpServer.cs
@@ -486,6 +486,12 @@ public class HttpServer : ServerBase
                 clientSocket.Dispose();
             }
 
+            // LogServiceにACL拒否ログを送信
+            _logCallback?.Invoke(
+                LogLevel.Warning,
+                _name,
+                $"ACL denied connection from {remoteIp}");
+
             Statistics.TotalErrors++;
             Metrics.IncrementErrors();
             return;


### PR DESCRIPTION
## 問題
HTTPサーバーでACLがアクセスを拒否した際、ILoggerではログが出力されるが、LogService（Web UIのログビューア）にログが送信されていなかった。

## 原因
HttpServer.csのACL拒否処理（466-492行目）で、`_logCallback`が呼ばれていなかった。通常のリクエスト処理では`_logCallback`が呼ばれ、LogServiceにログが送信される。

## 修正内容
ACL拒否時に`_logCallback`を呼び出し、LogServiceにログを送信するようにした（HttpServer.cs:489-493行目）。

### 変更したファイル
- `src/Jdx.Servers.Http/HttpServer.cs`

## テスト結果
- ビルド: 成功（26個の警告、0エラー）
- 既存テストの失敗はmainブランチでも同じ状態のため、今回の修正とは無関係

## 関連Issue
Closes #60