### PR TITLE
Update: #69 Virtual Host設定ページでもMessageDialogを使用するように統一

### DIFF
--- a/src/Jdx.WebUI/Components/Pages/Settings/Http/VirtualHostGeneral.razor
+++ b/src/Jdx.WebUI/Components/Pages/Settings/Http/VirtualHostGeneral.razor
@@ -3,9 +3,9 @@
 @using Jdx.Core.Settings
 @using Jdx.WebUI.Services
 @using System.Net.Http.Json
+@using Jdx.WebUI.Components.Shared
 @inject ISettingsService SettingsService
 @inject HttpClient HttpClient
-@inject IJSRuntime JSRuntime
 
 <PageTitle>HTTP Virtual Host Settings - JumboDogX</PageTitle>
 
@@ -118,6 +118,14 @@
     </div>
 </div>
 
+<MessageDialog IsVisible="@showErrorDialog"
+               Title="@errorDialogTitle"
+               Message="@errorDialogMessage"
+               ConfirmButtonText="OK"
+               ShowCancelButton="false"
+               Type="MessageDialog.DialogType.Error"
+               OnConfirm="CloseErrorDialog" />
+
 @code {
     [Parameter]
     public string VhostId { get; set; } = "";
@@ -130,6 +138,11 @@
     private string virtualHostName = "";
     private int port;
     private bool enableHttps;
+
+    // エラーダイアログ用
+    private bool showErrorDialog = false;
+    private string errorDialogTitle = "Error";
+    private string errorDialogMessage = "";
 
     protected override void OnInitialized()
     {
@@ -181,20 +194,20 @@
                     }
                     else
                     {
-                        // 検証失敗 - エラーをポップアップ表示
-                        await JSRuntime.InvokeVoidAsync("alert", result?.ErrorMessage ?? "証明書の検証に失敗しました。");
+                        // 検証失敗 - エラーダイアログを表示
+                        ShowErrorDialog("証明書の検証エラー", result?.ErrorMessage ?? "証明書の検証に失敗しました。");
 
                         // スイッチはOFFのまま（enableHttpsを変更しない）
                     }
                 }
                 else
                 {
-                    await JSRuntime.InvokeVoidAsync("alert", "証明書の検証APIの呼び出しに失敗しました。");
+                    ShowErrorDialog("証明書の検証エラー", "証明書の検証APIの呼び出しに失敗しました。");
                 }
             }
             catch (Exception ex)
             {
-                await JSRuntime.InvokeVoidAsync("alert", $"証明書の検証中にエラーが発生しました: {ex.Message}");
+                ShowErrorDialog("証明書の検証エラー", $"証明書の検証中にエラーが発生しました: {ex.Message}");
             }
         }
         else
@@ -259,5 +272,17 @@
 
         saveMessage = "Settings reset to default values. Click 'Save Settings' to apply.";
         saveSuccess = true;
+    }
+
+    private void ShowErrorDialog(string title, string message)
+    {
+        errorDialogTitle = title;
+        errorDialogMessage = message;
+        showErrorDialog = true;
+    }
+
+    private void CloseErrorDialog()
+    {
+        showErrorDialog = false;
     }
 }


### PR DESCRIPTION
## 概要
Virtual Host設定ページでHTTPS有効化時のエラーダイアログを、Logsページと同じスタイルのMessageDialogコンポーネントに統一しました。

## 変更内容
- VirtualHostGeneral.razorで古いブラウザアラート（JSRuntime.InvokeVoidAsync）を削除
- MessageDialogコンポーネントをインポートして使用
- エラーダイアログ用のプロパティとメソッド（ShowErrorDialog, CloseErrorDialog）を追加
- UI全体で一貫したダイアログスタイルを実現

## テスト結果
- ビルド: 成功
- 動作確認: Virtual Host設定ページでHTTPS有効化時にMessageDialogが正しく表示されることを確認

## 関連Issue
#69

🤖 Generated with [Claude Code](https://claude.com/claude-code)