### PR TITLE
Virtual Hostsメニューを階層化

### DIFF
--- a/src/Jdx.WebUI/Components/Layout/NavMenu.razor
+++ b/src/Jdx.WebUI/Components/Layout/NavMenu.razor
@@ -47,41 +47,48 @@
                         @if (httpExpanded)
                         {
                             <div class="submenu-items">
-                                <NavLink class="nav-link submenu-item" href="settings/http/virtualhost">Virtual Hosts</NavLink>
-
-                                @if (virtualHosts != null && virtualHosts.Count > 0)
-                                {
-                                    <!-- Virtual Hosts with individual settings -->
-                                    @foreach (var (vhost, index) in virtualHosts.Select((v, i) => (v, i)))
+                                <!-- Virtual Hosts subsection -->
+                                <div class="submenu-subsection">
+                                    <div class="submenu-subheader" @onclick:stopPropagation="true">
+                                        <span class="submenu-subtitle submenu-subtitle-clickable" @onclick="NavigateToVirtualHosts" @onclick:stopPropagation="true">Virtual Hosts</span>
+                                        <span class="submenu-arrow @(virtualHostsExpanded ? "expanded" : "")" @onclick="ToggleVirtualHostsSection" @onclick:stopPropagation="true">▼</span>
+                                    </div>
+                                    @if (virtualHostsExpanded && virtualHosts != null && virtualHosts.Count > 0)
                                     {
-                                        var vhostId = index.ToString();
-                                        var hostName = vhost.GetHostName();
-                                        var displayName = string.IsNullOrEmpty(hostName) ? $"Virtual Host #{index + 1}" : hostName;
-                                        var isVhostExpanded = virtualHostExpandedStates.ContainsKey(vhostId) && virtualHostExpandedStates[vhostId];
-
-                                        <div class="submenu-subsection">
-                                            <div class="submenu-subheader" @onclick="() => ToggleVirtualHost(vhostId)" @onclick:stopPropagation="true">
-                                                <span class="submenu-subtitle">@displayName</span>
-                                                <span class="submenu-arrow @(isVhostExpanded ? "expanded" : "")">▼</span>
-                                            </div>
-                                            @if (isVhostExpanded)
+                                        <div class="submenu-subitems">
+                                            <!-- Individual Virtual Hosts -->
+                                            @foreach (var (vhost, index) in virtualHosts.Select((v, i) => (v, i)))
                                             {
-                                                <div class="submenu-subitems">
-                                                    <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/general")">General</NavLink>
-                                                    <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/acl")">ACL</NavLink>
-                                                    <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/document")">Document</NavLink>
-                                                    <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/cgi")">CGI</NavLink>
-                                                    <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/ssi")">SSI</NavLink>
-                                                    <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/webdav")">WebDAV</NavLink>
-                                                    <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/alias-mime")">Alias & MIME</NavLink>
-                                                    <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/authentication")">Authentication</NavLink>
-                                                    <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/template")">Template</NavLink>
-                                                    <NavLink class="nav-link submenu-subitem" href="@($"settings/http/{vhostId}/advanced")">Advanced</NavLink>
+                                                var vhostId = index.ToString();
+                                                var hostName = vhost.GetHostName();
+                                                var displayName = string.IsNullOrEmpty(hostName) ? $"Virtual Host #{index + 1}" : hostName;
+                                                var isVhostExpanded = virtualHostExpandedStates.ContainsKey(vhostId) && virtualHostExpandedStates[vhostId];
+
+                                                <div class="submenu-subsubsection">
+                                                    <div class="submenu-subsubheader" @onclick="() => ToggleVirtualHost(vhostId)" @onclick:stopPropagation="true">
+                                                        <span class="submenu-subsubtitle">@displayName</span>
+                                                        <span class="submenu-arrow @(isVhostExpanded ? "expanded" : "")">▼</span>
+                                                    </div>
+                                                    @if (isVhostExpanded)
+                                                    {
+                                                        <div class="submenu-subsubitems">
+                                                            <NavLink class="nav-link submenu-subsubitem" href="@($"settings/http/{vhostId}/general")">General</NavLink>
+                                                            <NavLink class="nav-link submenu-subsubitem" href="@($"settings/http/{vhostId}/acl")">ACL</NavLink>
+                                                            <NavLink class="nav-link submenu-subsubitem" href="@($"settings/http/{vhostId}/document")">Document</NavLink>
+                                                            <NavLink class="nav-link submenu-subsubitem" href="@($"settings/http/{vhostId}/cgi")">CGI</NavLink>
+                                                            <NavLink class="nav-link submenu-subsubitem" href="@($"settings/http/{vhostId}/ssi")">SSI</NavLink>
+                                                            <NavLink class="nav-link submenu-subsubitem" href="@($"settings/http/{vhostId}/webdav")">WebDAV</NavLink>
+                                                            <NavLink class="nav-link submenu-subsubitem" href="@($"settings/http/{vhostId}/alias-mime")">Alias & MIME</NavLink>
+                                                            <NavLink class="nav-link submenu-subsubitem" href="@($"settings/http/{vhostId}/authentication")">Authentication</NavLink>
+                                                            <NavLink class="nav-link submenu-subsubitem" href="@($"settings/http/{vhostId}/template")">Template</NavLink>
+                                                            <NavLink class="nav-link submenu-subsubitem" href="@($"settings/http/{vhostId}/advanced")">Advanced</NavLink>
+                                                        </div>
+                                                    }
                                                 </div>
                                             }
                                         </div>
                                     }
-                                }
+                                </div>
                             </div>
                         }
                     </div>
@@ -217,6 +224,7 @@
     private bool dhcpExpanded = false;
     private bool pop3Expanded = false;
     private bool smtpExpanded = false;
+    private bool virtualHostsExpanded = false;
 
     private List<VirtualHostEntry>? virtualHosts;
     private Dictionary<string, bool> virtualHostExpandedStates = new();
@@ -238,12 +246,22 @@
             {
                 httpExpanded = true;
 
-                // Check if URL matches a Virtual Host path pattern
-                var parts = currentPath.Split('/');
-                if (parts.Length >= 3 && int.TryParse(parts[2], out var vhostIndex))
+                // Check if URL is Virtual Hosts management page or a specific Virtual Host page
+                if (currentPath == "settings/http/virtualhost")
                 {
-                    // URL is like settings/http/0/general - expand that Virtual Host
-                    virtualHostExpandedStates[vhostIndex.ToString()] = true;
+                    // Virtual Hosts management page - expand Virtual Hosts section
+                    virtualHostsExpanded = true;
+                }
+                else
+                {
+                    // Check if URL matches a Virtual Host path pattern
+                    var parts = currentPath.Split('/');
+                    if (parts.Length >= 3 && int.TryParse(parts[2], out var vhostIndex))
+                    {
+                        // URL is like settings/http/0/general - expand Virtual Hosts section and that Virtual Host
+                        virtualHostsExpanded = true;
+                        virtualHostExpandedStates[vhostIndex.ToString()] = true;
+                    }
                 }
             }
             else if (currentPath.StartsWith("settings/ftp/"))
@@ -331,6 +349,16 @@
     private void ToggleSmtp()
     {
         smtpExpanded = !smtpExpanded;
+    }
+
+    private void ToggleVirtualHostsSection()
+    {
+        virtualHostsExpanded = !virtualHostsExpanded;
+    }
+
+    private void NavigateToVirtualHosts()
+    {
+        Navigation.NavigateTo("settings/http/virtualhost");
     }
 
     private void ToggleVirtualHost(string vhostId)

--- a/src/Jdx.WebUI/Components/Layout/NavMenu.razor.css
+++ b/src/Jdx.WebUI/Components/Layout/NavMenu.razor.css
@@ -177,7 +177,7 @@
 
 .submenu-subtitle {
     flex-grow: 1;
-    font-size: 1.1rem !important;
+    font-size: 0.85rem !important;
     font-weight: 600 !important;
 }
 
@@ -198,6 +198,68 @@
 }
 
 .submenu-subitem:hover {
+    background-color: rgba(255,255,255,0.08) !important;
+}
+
+/* Virtual Hosts clickable subtitle */
+.submenu-subtitle-clickable {
+    cursor: pointer;
+    user-select: none;
+}
+
+.submenu-subtitle-clickable:hover {
+    color: white;
+}
+
+/* Fourth level - Individual Virtual Host items */
+.submenu-subsubsection {
+    margin-bottom: 0.25rem;
+    margin-left: 1rem;
+}
+
+.submenu-subsubheader {
+    color: #d7d7d7 !important;
+    font-size: 0.85rem !important;
+    font-weight: 500 !important;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    user-select: none;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+    min-height: 2.5rem;
+}
+
+.submenu-subsubheader:hover {
+    background-color: rgba(255,255,255,0.05);
+    border-radius: 4px;
+}
+
+.submenu-subsubtitle {
+    flex-grow: 1;
+    font-size: 0.85rem !important;
+    font-weight: 500 !important;
+    color: #d7d7d7 !important;
+}
+
+.submenu-subsubitems {
+    margin-left: 1rem;
+}
+
+.submenu-subsubitem {
+    font-size: 0.8rem !important;
+    height: 2.5rem !important;
+    line-height: 2.5rem !important;
+    padding-left: 4.5rem !important;
+}
+
+.submenu-subsubitem.active {
+    background-color: rgba(255,255,255,0.25) !important;
+    border-left: 3px solid #fff;
+}
+
+.submenu-subsubitem:hover {
     background-color: rgba(255,255,255,0.08) !important;
 }
 


### PR DESCRIPTION
## 概要
Virtual Hostsで追加したホスト（sample.com、example.comなど）が、Virtual Hostsの子階層として表示されるようにメニュー構造を変更しました。

## 変更内容
- **NavMenu.razor**
  - Virtual Hostsを親項目（subsection）として再構成
  - テキスト部分: クリックでVirtual Hosts管理ページ（settings/http/virtualhost）へ遷移
  - 矢印部分: クリックで各ホストの展開/折りたたみ
  - NavLinkをspanとクリックイベントに変更（activeスタイルによる下線・背景色・左バーの問題を解決）
  - virtualHostsExpanded状態変数とToggleVirtualHostsSection、NavigateToVirtualHostsメソッドを追加
  
- **NavMenu.razor.css**
  - 4階層メニューのスタイルを追加（submenu-subsubsection、submenu-subsubheader等）
  - フォントサイズと色の調整（Virtual Hosts: 0.85rem、ホスト名: 0.85rem、色: #d7d7d7）

## メニュー構造
**変更前:**
```
HTTP/HTTPS
├── Virtual Hosts
├── sample.com
└── example.com
```

**変更後:**
```
HTTP/HTTPS
└── Virtual Hosts
    ├── sample.com
    │   ├── General
    │   ├── ACL
    │   └── ...
    └── example.com
```

## テスト結果
- ビルド: 成功
- 動作確認: 
  - Virtual Hostsテキストクリックで管理ページへ遷移することを確認
  - 矢印クリックで各ホストの展開/折りたたみができることを確認
  - メニュー階層が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)