### PR TITLE
Fix: ACL UIの表示問題を修正

### DIFF
--- a/src/Jdx.WebUI/Components/Pages/Settings/Proxy/Acl.razor
+++ b/src/Jdx.WebUI/Components/Pages/Settings/Proxy/Acl.razor
@@ -29,38 +29,23 @@
                         AclList="@settings.ProxyServer.AclList"
                         AclListChanged="@OnAclListChanged">
                 <HelpSection>
-                    <div class="settings-card mb-4">
-                        <div class="card-header">
-                            <h5 class="mb-0">IP Address Format Help</h5>
-                        </div>
-                        <div class="card-body">
-                            <p class="mb-2">Supported formats for IP address entries:</p>
-                            <ul>
-                                <li><strong>Single IP:</strong> <code>192.168.1.100</code></li>
-                                <li><strong>CIDR Range:</strong> <code>192.168.1.0/24</code> (matches 192.168.1.0 - 192.168.1.255)</li>
-                                <li><strong>Wildcard:</strong> <code>192.168.*.*</code> (matches all 192.168.x.x)</li>
-                                <li><strong>Range:</strong> <code>192.168.1.1-192.168.1.50</code></li>
-                            </ul>
-
-                            <div class="alert alert-warning mt-3 mb-0">
-                                <strong>Important:</strong>
-                                <ul class="mb-0">
-                                    <li>In <strong>Allow Mode</strong>, if no entries exist, ALL connections are denied</li>
-                                    <li>In <strong>Deny Mode</strong>, if no entries exist, ALL connections are allowed</li>
-                                    <li>Test your ACL configuration carefully to avoid locking yourself out</li>
-                                </ul>
-                            </div>
-                        </div>
+                    <div class="alert alert-info">
+                        <strong>Supported Formats:</strong>
+                        <ul class="mb-0">
+                            <li><strong>Single IP</strong>: 192.168.1.100</li>
+                            <li><strong>CIDR Notation</strong>: 192.168.1.0/24 (matches 192.168.1.0 - 192.168.1.255)</li>
+                            <li><strong>IPv6</strong>: 2001:db8::1 or 2001:db8::/32</li>
+                        </ul>
                     </div>
                 </HelpSection>
             </AclManager>
 
             <div class="border-top pt-3 mt-4">
                 <button class="btn btn-dashboard btn-dashboard-primary btn-dashboard-lg me-2" @onclick="SaveSettings">
-                    <span class="bi bi-check-circle me-1"></span> Save Settings
+                    Save Settings
                 </button>
                 <button class="btn btn-dashboard btn-dashboard-outline btn-dashboard-lg" @onclick="ResetToDefault">
-                    <span class="bi bi-arrow-counterclockwise me-1"></span> Reset to Default
+                    Reset to Default
                 </button>
             </div>
         </div>

--- a/src/Jdx.WebUI/Components/_Imports.razor
+++ b/src/Jdx.WebUI/Components/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using Jdx.WebUI
 @using Jdx.WebUI.Components
+@using Jdx.WebUI.Components.Shared


### PR DESCRIPTION
## 概要
Phase 2で作成した共通ACLコンポーネント(AclManager)が表示されない問題と、ProxyページのUI不統一を修正しました。

## 変更内容
1. **ProxyページのUI統一** (`7eeeb37`)
   - ボタンからBootstrap Iconsを削除してFTPと同じシンプルなボタンに統一
   - HelpSectionの構造を`settings-card`から`alert alert-info`形式に変更
   - FTPページと完全に統一されたUIに

2. **AclManagerコンポーネントの表示修正** (`3e8553e`)
   - `src/Jdx.WebUI/Components/_Imports.razor`に`@using Jdx.WebUI.Components.Shared`を追加
   - 名前空間が不足していたため、全ACLページでAclManagerコンポーネントが表示されていなかった問題を解決

## 影響範囲
- FTP, DNS, POP3, TFTP, SMTP, Proxy, HTTPの全ACLページ
- 全ページで統一されたラジオボタン形式のACL Mode選択UIが正常に表示されるようになった

## テスト結果
- ビルド: 成功 (警告のみ、エラーなし)
- 手動テスト: 全ACLページで正常に表示・動作確認済み
  - FTP: http://localhost:5001/settings/ftp/acl ✅
  - DNS: http://localhost:5001/settings/dns/acl ✅
  - POP3: http://localhost:5001/settings/pop3/acl ✅
  - TFTP: http://localhost:5001/settings/tftp/acl ✅
  - SMTP: http://localhost:5001/settings/smtp/acl ✅
  - Proxy: http://localhost:5001/settings/proxy/acl ✅
  - HTTP: http://localhost:5001/settings/http/acl ✅

## スクリーンショット
修正後、全ACLページでラジオボタン形式のACL Modeとテーブル形式のACLリストが正常に表示されることを確認。

## 関連PR
- #79 (Phase 2: 共通ACLコンポーネント作成)