### PR TITLE
Logsページでdebugレベルのログを表示可能に (#85)

### DIFF
--- a/src/Jdx.WebUI/Components/Pages/Logs.razor
+++ b/src/Jdx.WebUI/Components/Pages/Logs.razor
@@ -19,6 +19,9 @@
             <button class="logs-filter-btn @(selectedLevel == null ? "active" : "")" @onclick="() => FilterByLevel(null)">
                 All
             </button>
+            <button class="logs-filter-btn debug @(selectedLevel == LogLevel.Debug ? "active" : "")" @onclick="() => FilterByLevel(LogLevel.Debug)">
+                Debug
+            </button>
             <button class="logs-filter-btn info @(selectedLevel == LogLevel.Information ? "active" : "")" @onclick="() => FilterByLevel(LogLevel.Information)">
                 Info
             </button>

--- a/src/Jdx.WebUI/appsettings.json
+++ b/src/Jdx.WebUI/appsettings.json
@@ -1,8 +1,9 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Warning",
+      "Jdx.Servers.Dns": "Debug"
     }
   },
   "AllowedHosts": "*",
@@ -109,119 +110,11 @@
       "MaxRangeCount": 20,
       "CertificateFile": "",
       "CertificatePassword": "",
-      "VirtualHosts": [
-        {
-          "Host": "example.com:8080",
-          "Enabled": true,
-          "BindAddress": "127.0.0.1",
-          "Settings": {
-            "Protocol": "HTTP",
-            "DocumentRoot": "/Users/hirauchi.shinichi/Downloads/MyTools/jumbodogx/samples/www",
-            "WelcomeFileName": "index.html",
-            "UseHidden": false,
-            "UseDot": false,
-            "UseDirectoryEnum": false,
-            "UseExpansion": false,
-            "ServerHeader": "JumboDogX Version $v",
-            "UseEtag": false,
-            "ServerAdmin": "",
-            "UseCgi": false,
-            "CgiCommands": [],
-            "CgiTimeout": 10,
-            "CgiPaths": [],
-            "UseSsi": false,
-            "SsiExt": "html,htm",
-            "UseExec": false,
-            "UseWebDav": false,
-            "WebDavPaths": [],
-            "Aliases": [],
-            "MimeTypes": [
-              {
-                "Extension": "txt",
-                "MimeType": "text/plain"
-              },
-              {
-                "Extension": "html",
-                "MimeType": "text/html"
-              },
-              {
-                "Extension": "htm",
-                "MimeType": "text/html"
-              },
-              {
-                "Extension": "css",
-                "MimeType": "text/css"
-              },
-              {
-                "Extension": "js",
-                "MimeType": "text/javascript"
-              },
-              {
-                "Extension": "json",
-                "MimeType": "application/json"
-              },
-              {
-                "Extension": "xml",
-                "MimeType": "text/xml"
-              },
-              {
-                "Extension": "gif",
-                "MimeType": "image/gif"
-              },
-              {
-                "Extension": "jpg",
-                "MimeType": "image/jpeg"
-              },
-              {
-                "Extension": "jpeg",
-                "MimeType": "image/jpeg"
-              },
-              {
-                "Extension": "png",
-                "MimeType": "image/png"
-              },
-              {
-                "Extension": "svg",
-                "MimeType": "image/svg\u002Bxml"
-              },
-              {
-                "Extension": "pdf",
-                "MimeType": "application/pdf"
-              },
-              {
-                "Extension": "zip",
-                "MimeType": "application/zip"
-              }
-            ],
-            "AuthList": [],
-            "UserList": [],
-            "GroupList": [],
-            "Encode": "UTF-8",
-            "IndexDocument": "",
-            "ErrorDocument": "",
-            "EnableAcl": 0,
-            "AclList": [
-              {
-                "Name": "localhost",
-                "Address": "127.0.0.1"
-              }
-            ],
-            "CertificateFile": "",
-            "CertificatePassword": "",
-            "UseAutoAcl": false,
-            "AutoAclApacheKiller": false,
-            "UseKeepAlive": true,
-            "KeepAliveTimeout": 5,
-            "MaxKeepAliveRequests": 100,
-            "UseRangeRequests": true,
-            "MaxRangeCount": 20
-          }
-        }
-      ]
+      "VirtualHosts": []
     },
     "DnsServer": {
-      "Enabled": false,
-      "Port": 53,
+      "Enabled": true,
+      "Port": 5354,
       "BindAddress": "0.0.0.0",
       "MaxConnections": 10,
       "TimeOut": 30,
@@ -235,44 +128,129 @@
       "SoaMinimum": 3600,
       "DomainList": [
         {
-          "Name": "localhost",
-          "IsAuthority": true
-        },
-        {
-          "Name": "test.local",
-          "IsAuthority": true
+          "Name": "example.com.",
+          "IsAuthority": true,
+          "SoaPrimaryNameServer": "ns.example.com.",
+          "SoaMail": "postmaster",
+          "SoaSerial": 1,
+          "SoaRefresh": 3600,
+          "SoaRetry": 300,
+          "SoaExpire": 360000,
+          "SoaMinimum": 3600
         }
       ],
       "ResourceList": [
+        {
+          "Type": 2,
+          "Name": "example.com.",
+          "Alias": "",
+          "Address": "ns.example.com.",
+          "Priority": 0,
+          "Ttl": 3600,
+          "NameServers": []
+        },
         {
           "Type": 1,
           "Name": "localhost",
           "Alias": "",
           "Address": "127.0.0.1",
-          "Priority": 0
+          "Priority": 0,
+          "Ttl": 3600,
+          "NameServers": []
         },
         {
           "Type": 28,
           "Name": "localhost",
           "Alias": "",
           "Address": "::1",
-          "Priority": 0
+          "Priority": 0,
+          "Ttl": 3600,
+          "NameServers": []
         },
         {
           "Type": 1,
           "Name": "test.local",
           "Alias": "",
           "Address": "192.168.1.100",
-          "Priority": 0
+          "Priority": 0,
+          "Ttl": 3600,
+          "NameServers": []
+        },
+        {
+          "Type": 5,
+          "Name": "localhost",
+          "Alias": "www.google.com",
+          "Address": "",
+          "Priority": 0,
+          "Ttl": 3600,
+          "NameServers": []
+        },
+        {
+          "Type": 1,
+          "Name": "www",
+          "Alias": "",
+          "Address": "192.168.1.1",
+          "Priority": 0,
+          "Ttl": 3600,
+          "NameServers": []
+        },
+        {
+          "Type": 1,
+          "Name": "www",
+          "Alias": "",
+          "Address": "",
+          "Priority": 0,
+          "Ttl": 3600,
+          "NameServers": []
+        },
+        {
+          "Type": 5,
+          "Name": "www2",
+          "Alias": "www.google.com",
+          "Address": "",
+          "Priority": 0,
+          "Ttl": 3600,
+          "NameServers": []
+        },
+        {
+          "Type": 1,
+          "Name": "www",
+          "Alias": "",
+          "Address": "192.168.1.1",
+          "Priority": 0,
+          "Ttl": 3600,
+          "NameServers": []
+        },
+        {
+          "Type": 1,
+          "Name": "www",
+          "Alias": "",
+          "Address": "192.168.1.1",
+          "Priority": 0,
+          "Ttl": 3600,
+          "NameServers": []
+        },
+        {
+          "Type": 1,
+          "Name": "www",
+          "Alias": "",
+          "Address": "192.168.1.1",
+          "Priority": 0,
+          "Ttl": 3600,
+          "NameServers": []
+        },
+        {
+          "Type": 1,
+          "Name": "www2.example.com.",
+          "Alias": "",
+          "Address": "1.1.1.1",
+          "Priority": 0,
+          "Ttl": 3600,
+          "NameServers": []
         }
       ],
-      "EnableAcl": 0,
-      "AclList": [
-        {
-          "Name": "LocalNetwork",
-          "Address": "192.168.1.0/24"
-        }
-      ]
+      "EnableAcl": 1,
+      "AclList": []
     },
     "FtpServer": {
       "Enabled": true,
@@ -504,7 +482,7 @@
       "AclList": []
     },
     "Logging": {
-      "LogLevel": "Information",
+      "LogLevel": "Debug",
       "MaxEntries": 1000
     }
   }

--- a/src/Jdx.WebUI/appsettings.json
+++ b/src/Jdx.WebUI/appsettings.json
@@ -2,8 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Debug",
-      "Microsoft.AspNetCore": "Warning",
-      "Jdx.Servers.Dns": "Debug"
+      "Microsoft.AspNetCore": "Warning"
     }
   },
   "AllowedHosts": "*",
@@ -110,11 +109,119 @@
       "MaxRangeCount": 20,
       "CertificateFile": "",
       "CertificatePassword": "",
-      "VirtualHosts": []
+      "VirtualHosts": [
+        {
+          "Host": "example.com:8080",
+          "Enabled": true,
+          "BindAddress": "127.0.0.1",
+          "Settings": {
+            "Protocol": "HTTP",
+            "DocumentRoot": "/Users/hirauchi.shinichi/Downloads/MyTools/jumbodogx/samples/www",
+            "WelcomeFileName": "index.html",
+            "UseHidden": false,
+            "UseDot": false,
+            "UseDirectoryEnum": false,
+            "UseExpansion": false,
+            "ServerHeader": "JumboDogX Version $v",
+            "UseEtag": false,
+            "ServerAdmin": "",
+            "UseCgi": false,
+            "CgiCommands": [],
+            "CgiTimeout": 10,
+            "CgiPaths": [],
+            "UseSsi": false,
+            "SsiExt": "html,htm",
+            "UseExec": false,
+            "UseWebDav": false,
+            "WebDavPaths": [],
+            "Aliases": [],
+            "MimeTypes": [
+              {
+                "Extension": "txt",
+                "MimeType": "text/plain"
+              },
+              {
+                "Extension": "html",
+                "MimeType": "text/html"
+              },
+              {
+                "Extension": "htm",
+                "MimeType": "text/html"
+              },
+              {
+                "Extension": "css",
+                "MimeType": "text/css"
+              },
+              {
+                "Extension": "js",
+                "MimeType": "text/javascript"
+              },
+              {
+                "Extension": "json",
+                "MimeType": "application/json"
+              },
+              {
+                "Extension": "xml",
+                "MimeType": "text/xml"
+              },
+              {
+                "Extension": "gif",
+                "MimeType": "image/gif"
+              },
+              {
+                "Extension": "jpg",
+                "MimeType": "image/jpeg"
+              },
+              {
+                "Extension": "jpeg",
+                "MimeType": "image/jpeg"
+              },
+              {
+                "Extension": "png",
+                "MimeType": "image/png"
+              },
+              {
+                "Extension": "svg",
+                "MimeType": "image/svg\u002Bxml"
+              },
+              {
+                "Extension": "pdf",
+                "MimeType": "application/pdf"
+              },
+              {
+                "Extension": "zip",
+                "MimeType": "application/zip"
+              }
+            ],
+            "AuthList": [],
+            "UserList": [],
+            "GroupList": [],
+            "Encode": "UTF-8",
+            "IndexDocument": "",
+            "ErrorDocument": "",
+            "EnableAcl": 0,
+            "AclList": [
+              {
+                "Name": "localhost",
+                "Address": "127.0.0.1"
+              }
+            ],
+            "CertificateFile": "",
+            "CertificatePassword": "",
+            "UseAutoAcl": false,
+            "AutoAclApacheKiller": false,
+            "UseKeepAlive": true,
+            "KeepAliveTimeout": 5,
+            "MaxKeepAliveRequests": 100,
+            "UseRangeRequests": true,
+            "MaxRangeCount": 20
+          }
+        }
+      ]
     },
     "DnsServer": {
-      "Enabled": true,
-      "Port": 5354,
+      "Enabled": false,
+      "Port": 53,
       "BindAddress": "0.0.0.0",
       "MaxConnections": 10,
       "TimeOut": 30,
@@ -128,129 +235,44 @@
       "SoaMinimum": 3600,
       "DomainList": [
         {
-          "Name": "example.com.",
-          "IsAuthority": true,
-          "SoaPrimaryNameServer": "ns.example.com.",
-          "SoaMail": "postmaster",
-          "SoaSerial": 1,
-          "SoaRefresh": 3600,
-          "SoaRetry": 300,
-          "SoaExpire": 360000,
-          "SoaMinimum": 3600
+          "Name": "localhost",
+          "IsAuthority": true
+        },
+        {
+          "Name": "test.local",
+          "IsAuthority": true
         }
       ],
       "ResourceList": [
-        {
-          "Type": 2,
-          "Name": "example.com.",
-          "Alias": "",
-          "Address": "ns.example.com.",
-          "Priority": 0,
-          "Ttl": 3600,
-          "NameServers": []
-        },
         {
           "Type": 1,
           "Name": "localhost",
           "Alias": "",
           "Address": "127.0.0.1",
-          "Priority": 0,
-          "Ttl": 3600,
-          "NameServers": []
+          "Priority": 0
         },
         {
           "Type": 28,
           "Name": "localhost",
           "Alias": "",
           "Address": "::1",
-          "Priority": 0,
-          "Ttl": 3600,
-          "NameServers": []
+          "Priority": 0
         },
         {
           "Type": 1,
           "Name": "test.local",
           "Alias": "",
           "Address": "192.168.1.100",
-          "Priority": 0,
-          "Ttl": 3600,
-          "NameServers": []
-        },
-        {
-          "Type": 5,
-          "Name": "localhost",
-          "Alias": "www.google.com",
-          "Address": "",
-          "Priority": 0,
-          "Ttl": 3600,
-          "NameServers": []
-        },
-        {
-          "Type": 1,
-          "Name": "www",
-          "Alias": "",
-          "Address": "192.168.1.1",
-          "Priority": 0,
-          "Ttl": 3600,
-          "NameServers": []
-        },
-        {
-          "Type": 1,
-          "Name": "www",
-          "Alias": "",
-          "Address": "",
-          "Priority": 0,
-          "Ttl": 3600,
-          "NameServers": []
-        },
-        {
-          "Type": 5,
-          "Name": "www2",
-          "Alias": "www.google.com",
-          "Address": "",
-          "Priority": 0,
-          "Ttl": 3600,
-          "NameServers": []
-        },
-        {
-          "Type": 1,
-          "Name": "www",
-          "Alias": "",
-          "Address": "192.168.1.1",
-          "Priority": 0,
-          "Ttl": 3600,
-          "NameServers": []
-        },
-        {
-          "Type": 1,
-          "Name": "www",
-          "Alias": "",
-          "Address": "192.168.1.1",
-          "Priority": 0,
-          "Ttl": 3600,
-          "NameServers": []
-        },
-        {
-          "Type": 1,
-          "Name": "www",
-          "Alias": "",
-          "Address": "192.168.1.1",
-          "Priority": 0,
-          "Ttl": 3600,
-          "NameServers": []
-        },
-        {
-          "Type": 1,
-          "Name": "www2.example.com.",
-          "Alias": "",
-          "Address": "1.1.1.1",
-          "Priority": 0,
-          "Ttl": 3600,
-          "NameServers": []
+          "Priority": 0
         }
       ],
-      "EnableAcl": 1,
-      "AclList": []
+      "EnableAcl": 0,
+      "AclList": [
+        {
+          "Name": "LocalNetwork",
+          "Address": "192.168.1.0/24"
+        }
+      ]
     },
     "FtpServer": {
       "Enabled": true,
@@ -482,7 +504,7 @@
       "AclList": []
     },
     "Logging": {
-      "LogLevel": "Debug",
+      "LogLevel": "Information",
       "MaxEntries": 1000
     }
   }

--- a/src/Jdx.WebUI/wwwroot/app.css
+++ b/src/Jdx.WebUI/wwwroot/app.css
@@ -584,6 +584,11 @@ h1:focus {
     border-color: var(--btn-danger);
 }
 
+.logs-filter-btn.debug.active {
+    background-color: #4A5568;
+    border-color: #4A5568;
+}
+
 .logs-table-container {
     background-color: var(--card-bg);
     border: 1px solid var(--card-border);


### PR DESCRIPTION
## 概要
Logsページでdebugレベルのログが表示されない問題を修正しました。

## 変更内容
- **appsettings.json**: `Logging.LogLevel`を`"Information"`から`"Debug"`に変更
- **Logs.razor**: UIにDebugフィルタボタンを追加（AllとInfoの間に配置）

## テスト結果
- ビルド: ✓ 成功
- テスト: ✓ 全テスト成功（566テスト）

## 関連Issue
Closes #85

## レビューのポイント
- debugレベルのログが正しく表示されるか
- Debugフィルタボタンの配置が適切か
- ログレベル設定の変更が他の機能に影響しないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

@claude 自動的にレビューして下さい