### PR TITLE
Docs: Issue #85対応に伴うドキュメント更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@
 
 - [JumboDogX プロジェクト概要](docs/00_project/01_project_overview.md)
 - [技術スタック](docs/00_project/02_tech_stack.md)
+- [仕様書サマリー](docs/00_project/03_specification_summary.md)
 
 ### 開発ドキュメント
 
@@ -35,6 +36,10 @@
 
 - [Web UI 概要](docs/03_web_ui/01_web_ui_overview.md)
 - [コンポーネント設計](docs/03_web_ui/02_components.md)
+
+### セキュリティ
+
+- [ACL（アクセス制御リスト）](docs/04_acl/01_acl_overview.md)
 
 
 ## クイックスタート

--- a/README.ja.md
+++ b/README.ja.md
@@ -65,7 +65,7 @@ jdx/
 
 ### Web UI（Blazor Server）
 - Dashboard実装済み（サーバー状態監視）
-- Logs実装済み（IPアドレス追跡機能付きリアルタイムログ表示）
+- Logs実装済み（Debugレベル含むログレベルフィルタ、IPアドレス追跡、自動更新機能付きリアルタイムログ表示）
 - 全サーバーの設定ページ実装済み（100%カバレッジ）
   - HTTP/HTTPS: General、Document、CGI、SSI、WebDAV、Alias & MIME、Authentication、Template、ACL、Virtual Hosts、SSL/TLS、Advanced
   - DNS: General、Recordsマネージメント

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ jdx/
 
 ### Web UI (Blazor Server)
 - Dashboard implemented (server status monitoring)
-- Logs viewer implemented (real-time log display with IP address tracking)
+- Logs viewer implemented (real-time log display with level filtering including Debug, IP address tracking, auto-refresh)
 - Settings pages for all servers implemented (100% coverage)
   - HTTP/HTTPS: General, Document, CGI, SSI, WebDAV, Alias & MIME, Authentication, Template, ACL, Virtual Hosts, SSL/TLS, Advanced
   - DNS: General, Records management

--- a/docs/01_development_docs/04_logging_design.md
+++ b/docs/01_development_docs/04_logging_design.md
@@ -82,11 +82,12 @@ public class LogService
 
 ### 5.2 ログビューア機能
 
-- レベルフィルタ（Info, Warning, Error）
+- レベルフィルタ（All, Debug, Info, Warning, Error）
 - カテゴリフィルタ
 - テキスト検索
 - 時刻フォーマット選択
 - ログクリア（確認ダイアログ付き）
+- リサイズ可能なカラム
 
 ## 6. 設定
 
@@ -96,7 +97,7 @@ public class LogService
 {
   "Serilog": {
     "MinimumLevel": {
-      "Default": "Information",
+      "Default": "Debug",
       "Override": {
         "Microsoft": "Warning",
         "System": "Warning"
@@ -115,6 +116,8 @@ public class LogService
   }
 }
 ```
+
+**注記:** デフォルトのログレベルは `Debug` に設定されており、Web UIのログビューアでDebugレベルのログを表示できます。本番環境では必要に応じて `Information` に変更してください。
 
 ## 7. パフォーマンス考慮事項
 
@@ -136,3 +139,9 @@ if (_logger.IsEnabled(LogEventLevel.Debug))
 ### 7.3 サンプリング
 
 大量ログ発生時はサンプリングを検討。
+
+## 更新履歴
+
+- 2026-01-27: Debugレベルのログ表示機能を追加（Issue #85対応）
+  - ログビューアにDebugフィルタボタンを追加
+  - デフォルトログレベルをDebugに変更

--- a/docs/03_web_ui/02_components.md
+++ b/docs/03_web_ui/02_components.md
@@ -55,13 +55,14 @@
 
 **機能:**
 - ログエントリ一覧
-- レベルフィルタボタン
+- レベルフィルタボタン（All, Debug, Info, Warning, Error）
 - カテゴリセレクト
 - テキスト検索
-- 時刻フォーマット選択
+- 時刻フォーマット選択（yyyy/MM/dd HH:mm:ss.fff, yyyy/MM/dd HH:mm:ss, HH:mm:ss.fff）
 - クリアボタン（確認ダイアログ付き）
 - リサイズ可能なカラム
 - IP Addressカラム（クライアントIPアドレスを表示）
+- 自動更新（500ms間隔）
 
 **状態管理:**
 ```csharp
@@ -72,7 +73,15 @@ private string selectedCategory = "";
 private string searchText = "";
 private string selectedTimeFormat = "HH:mm:ss.fff";
 private bool showClearConfirmDialog = false;
+private System.Threading.Timer? refreshTimer;
 ```
+
+**レベルフィルタ:**
+- **All**: すべてのログレベルを表示
+- **Debug**: デバッグレベルのログのみ表示
+- **Info**: 情報レベルのログのみ表示
+- **Warning**: 警告レベルのログのみ表示
+- **Error**: エラーレベルのログのみ表示
 
 ### 2.3 DnsRecords.razor
 
@@ -131,6 +140,12 @@ DNSレコード管理。
     @level
 </span>
 ```
+
+**レベル別スタイル:**
+- `debug`: デバッグレベル（グレー系）
+- `info`: 情報レベル（ブルー系）
+- `warning`: 警告レベル（イエロー系）
+- `error`: エラーレベル（レッド系）
 
 ## 4. スタイルガイド
 
@@ -208,6 +223,10 @@ DNSレコード管理。
 
 ## 更新履歴
 
+- 2026-01-27: Logs.razorにDebugレベルフィルタを追加（Issue #85対応）
+  - レベルフィルタにDebugボタンを追加
+  - 自動更新機能を追加（500ms間隔）
+  - 時刻フォーマット選択機能を追加
 - 2026-01-24: Server LogsページにIP Addressカラムを追加
 - 2026-01-24: NavMenu.razorにVirtual Hostsの階層構造を追加（PR #75）
 - 2026-01-24: NavMenu.razorにDomainsの階層構造を追加（PR #76）


### PR DESCRIPTION
## 概要
Issue #85（Logsページでdebugレベルのログ表示機能追加）に伴い、関連する技術ドキュメントとREADMEを最新の状態に更新しました。

## 変更内容

### 1. ロギング設計ドキュメント (`docs/01_development_docs/04_logging_design.md`)
- ログビューア機能の説明を更新
  - レベルフィルタに「Debug」を追加
  - リサイズ可能なカラム機能を追加
- `appsettings.json`の設定例を更新（デフォルトログレベル: `Debug`）
- 本番環境での設定変更に関する注記を追加
- 更新履歴を追加（2026-01-27）

### 2. コンポーネント設計ドキュメント (`docs/03_web_ui/02_components.md`)
- `Logs.razor`コンポーネントの詳細な機能説明を追加
  - レベルフィルタ: All, Debug, Info, Warning, Error
  - 時刻フォーマット選択: 3種類のフォーマット対応
  - 自動更新機能: 500ms間隔
- ログレベルバッジのスタイル別説明を追加
- 更新履歴を追加（2026-01-27）

### 3. CLAUDE.md
- 新規追加されたドキュメントへのリンクを追加
  - 仕様書サマリー (`docs/00_project/03_specification_summary.md`)
  - ACL概要 (`docs/04_acl/01_acl_overview.md`)
- セキュリティセクションを新設

### 4. README.md / README.ja.md
- Web UIのLogs viewer機能の説明を更新
  - Debugレベルフィルタ機能を明記
  - 自動更新機能を明記

## 変更統計
- 5ファイル変更
- 39行追加、6行削除

## テスト結果
- ドキュメントのリンク切れチェック: ✓ すべてのリンクが有効
- Markdown構文チェック: ✓ エラーなし
- CLAUDE.mdとdocs/配下の整合性: ✓ 一致

## レビューのポイント
- ドキュメントの内容が実装と整合しているか
- 更新履歴の日付が正しいか
- README.mdとREADME.ja.mdの内容が一致しているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)